### PR TITLE
Add Concurrency for dispather

### DIFF
--- a/cmd/orchestrator/cncf.go
+++ b/cmd/orchestrator/cncf.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"gopkg.in/yaml.v2"
 	"github.com/cloudnative-id/announcer-system/models"
 	"github.com/cloudnative-id/announcer-system/handlers"
 )
 
-func CNCFNewsRoom(session handlers.Github, telegramBot TelegramDispatcher)(){
+func CNCFNewsRoom(session handlers.Github, telegramBot TelegramDispatcher, wg *sync.WaitGroup)(){
+	defer wg.Done()
 	contentTmpl := session.GetFile("cloudnative-id","announcer-system","./resources/cncf-newsroom/content.yaml")
 	
 	var pushRepository = false
@@ -36,7 +38,8 @@ func CNCFNewsRoom(session handlers.Github, telegramBot TelegramDispatcher)(){
 	}
 }
 
-func CNCFWebinar(session handlers.Github, telegramBot TelegramDispatcher)(){
+func CNCFWebinar(session handlers.Github, telegramBot TelegramDispatcher, wg *sync.WaitGroup)(){
+	defer wg.Done()
 	contentTmpl := session.GetFile("cloudnative-id","announcer-system","./resources/cncf-webinar/content.yaml")
 	
 	var pushRepository = false

--- a/cmd/orchestrator/kubeweekly.go
+++ b/cmd/orchestrator/kubeweekly.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"gopkg.in/yaml.v2"
 	"github.com/cloudnative-id/announcer-system/models"
 	"github.com/cloudnative-id/announcer-system/handlers"
 )
 
-func Kubeweekly(session handlers.Github, telegramBot TelegramDispatcher)(){
+func Kubeweekly(session handlers.Github, telegramBot TelegramDispatcher, wg *sync.WaitGroup)(){
+	defer wg.Done()
 	ConfigTmpl := session.GetFile("cloudnative-id","announcer-system","./resources/kubeweekly/kubeweekly.yaml")
 	
 	var PushRepository = false

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"sync"
 	"github.com/cloudnative-id/announcer-system/handlers"
 )
 
@@ -13,10 +14,15 @@ func main() {
 	var telegramBot TelegramDispatcher
 	telegramBot.StartBot()
 
-	Kubeweekly(session, telegramBot)
-	CNCFNewsRoom(session, telegramBot)
-	CNCFWebinar(session, telegramBot)
+	total := 3
+    var wg sync.WaitGroup
+    wg.Add(total)
+
+	go Kubeweekly(session, telegramBot, &wg)
+	go CNCFNewsRoom(session, telegramBot, &wg)
+	go CNCFWebinar(session, telegramBot, &wg)
+	wg.Wait()
+
 	NewMeetup(session, telegramBot)
 	PostMeetup(session, telegramBot)
-
 }


### PR DESCRIPTION
- Implement goroutine for kubeweeky, CNCF newsroom, CNCF webinar.
- cannot implement goroutine for meetup because meetup send 2 message.
